### PR TITLE
Handle percent-encoded URLs in CeylonRuntime

### DIFF
--- a/CeylonRuntime/src/org/intellij/plugins/ceylon/runtime/CeylonRuntime.java
+++ b/CeylonRuntime/src/org/intellij/plugins/ceylon/runtime/CeylonRuntime.java
@@ -10,6 +10,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -75,7 +76,11 @@ public class CeylonRuntime extends PluginCeylonStartup {
 
                     @Override
                     public File artifact() throws RepositoryException {
-                        return new File(url.getPath());
+                        try {
+                            return new File(url.toURI());
+                        } catch (URISyntaxException e) {
+                            throw new RepositoryException(e);
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
Ceylon plugin crashes on start if IntelliJ IDEA path contains spaces encoded as "%20"s. This PR fixes the problem. Alternative solutions can be found here: https://stackoverflow.com/questions/2166039/java-how-to-get-a-file-from-an-escaped-url

Thanks!