### PR TITLE
Needs to have shared annotation so can be runnable

### DIFF
--- a/resources/fileTemplates/internal/run.ceylon.ft
+++ b/resources/fileTemplates/internal/run.ceylon.ft
@@ -1,5 +1,5 @@
 "Run the module `${MODULE_NAME}`."
 
-void run() {
+shared void run() {
 
 }


### PR DESCRIPTION
The shared annotation needs to be added to the run method so that it can be run by default.