### PR TITLE
Partially implemented #144. Copy reference works fine. Still two more…

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -120,6 +120,7 @@
         <psi.classFileDecompiler implementation="org.intellij.plugins.ceylon.ide.compiled.CeylonDecompiler"/>
         <stubElementTypeHolder class="org.intellij.plugins.ceylon.ide.ceylonCode.psi.CeylonTypes"/>
         <stubIndex implementation="org.intellij.plugins.ceylon.ide.ceylonCode.psi.stub.ClassIndex"/>
+        <qualifiedNameProvider implementation="org.intellij.plugins.ceylon.ide.lang.CeylonQualifiedNameProvider"/>
         <!--<stubIndex implementation="org.intellij.plugins.ceylon.psi.stub.ModuleIndex"/>-->
 
         <gotoClassContributor implementation="org.intellij.plugins.ceylon.ide.ceylonCode.codeInsight.navigation.CeylonGotoClassContributor"/>

--- a/src/org/intellij/plugins/ceylon/ide/lang/CeylonQualifiedNameProvider.java
+++ b/src/org/intellij/plugins/ceylon/ide/lang/CeylonQualifiedNameProvider.java
@@ -1,0 +1,51 @@
+package org.intellij.plugins.ceylon.ide.lang;
+
+import com.intellij.ide.actions.QualifiedNameProvider;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.redhat.ceylon.compiler.typechecker.tree.Node;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree;
+import org.intellij.plugins.ceylon.ide.ceylonCode.psi.CeylonCompositeElement;
+import org.intellij.plugins.ceylon.ide.ceylonCode.psi.CeylonPsi;
+import org.jetbrains.annotations.Nullable;
+
+public class CeylonQualifiedNameProvider implements QualifiedNameProvider {
+    @Nullable
+    @Override
+    public PsiElement adjustElementToCopy(PsiElement element) {
+        if (element instanceof CeylonCompositeElement) {
+            CeylonCompositeElement ceylonElement = (CeylonCompositeElement) element;
+            if (ceylonElement instanceof CeylonPsi.IdentifierPsi) {
+                ceylonElement = (CeylonCompositeElement) element.getParent();
+            }
+            return ceylonElement;
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getQualifiedName(PsiElement element) {
+        if (element instanceof CeylonCompositeElement) {
+            CeylonCompositeElement ceylonElement = (CeylonCompositeElement) element;
+            Node ceylonNode = ceylonElement.getCeylonNode();
+            if (ceylonNode instanceof Tree.Declaration) {
+                Tree.Declaration declaration = (Tree.Declaration) ceylonNode;
+                return declaration.getDeclarationModel().getQualifiedNameString();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public PsiElement qualifiedNameToElement(String fqn, Project project) {
+        //TODO: Copy reference #144. Implement after https://github.com/ceylon/ceylon-ide-common/issues/57 .
+        return null;
+    }
+
+    @Override
+    public void insertQualifiedName(String fqn, PsiElement element, Editor editor, Project project) {
+        //TODO: Copy reference #144. Implement after https://github.com/ceylon/ceylon-ide-common/issues/57 .
+    }
+}


### PR DESCRIPTION
Partially implemented #144. Copy reference works fine. Still two more methods need implementation for IDE to handle paste nicely.

`adjustElementToCopy` and `getQualifiedName` implemented. 
`qualifiedNameToElement` and `insertQualifiedName` I'll implement when https://github.com/ceylon/ceylon-ide-common/issues/57 is done.
